### PR TITLE
Fix BIOS32 so it can be more reliable

### DIFF
--- a/NEW KERNEL/BIOS32/src/asm/bios32_call.asm
+++ b/NEW KERNEL/BIOS32/src/asm/bios32_call.asm
@@ -13,18 +13,35 @@ section .text
     global bios32_out_reg16_ptr ; OUT REGISTERS16
     global bios32_int_number_ptr ; bios interrupt number to be called
 
+ENABLE_PAGING equ 0x80000001
+DISABLE_PAGING equ 0x7FFFFFFF
+
 ; 32 bit protected mode
 BIOS32_START:use32
+    pushf
     pusha
-    ; save current esp to edx
-    mov edx, esp
-    ; jumping to 16 bit protected mode
-    ; disable interrupts
+
+    ; Save the original IDTR and GDTR onto the stack
+    sub esp, 32
+    sidt [esp]
+    sgdt [esp+16]
+
+    ; Save current protected mode ESP
+    mov [REBASE_ADDRESS(prot_esp)], esp
+
+    ; Jumping to 16-bit protected mode, disable interrupts
     cli
-    ; clear cr3 by saving cr3 data in ebx register
-    xor ecx, ecx
-    mov ebx, cr3
-    mov cr3, ecx
+
+    ; Turn off paging
+    mov eax, cr0
+    and eax, DISABLE_PAGING
+    mov cr0, eax
+
+    ; Flush the TLB
+    mov eax, cr3
+    mov cr3, eax
+
+
     ; load new empty GDT
     lgdt [REBASE_ADDRESS(bios32_gdt_ptr)]
     ; load new empty IDT
@@ -57,8 +74,8 @@ __real_mode_16:use16
     mov gs, ax
     mov ss, ax
     mov sp, 0x8c00
-    ; enable bios interrupts to call
-    sti
+    ; bios interrupts cannot be enabled because IRQs have been remapped, external interrupts will cause page faults/bad things
+    ; sti
     ; save current context, all general, segment registers, flags
     pusha
     mov cx, ss
@@ -73,11 +90,11 @@ __real_mode_16:use16
     push cx
     pushf
     ; get current stack pointer & save it to current_esp
-    mov ax, sp
-    mov edi, current_esp
-    stosw
+    mov eax, esp
+    mov edi, REBASE_ADDRESS(current_esp)
+    stosd
     ; load our custom registers context
-    mov esp, REBASE_ADDRESS(bios32_in_reg16_ptr)
+    mov sp, REBASE_ADDRESS(bios32_in_reg16_ptr)
     ; only use some general register from the given context
     popa
     ; set a new stack for bios interrupt
@@ -105,9 +122,9 @@ bios32_int_number_ptr: ; will be bios interrupt number passed
     push cx
     pusha
     ; restore the current_esp to continue
-    mov esi, current_esp
-    lodsw
-    mov sp, ax
+    mov esi, REBASE_ADDRESS(current_esp)
+    lodsd
+    mov esp, eax
     ; restore all current context, all general, segment registers, flags
     popf
     pop cx
@@ -124,6 +141,7 @@ bios32_int_number_ptr: ; will be bios interrupt number passed
 
     ; jumping to 32 bit protected mode
     ; set bit 0 in cr0 to 1
+    cli
     mov eax, cr0
     inc eax
     mov cr0, eax
@@ -137,22 +155,28 @@ __protected_mode_32:use32
     mov fs, ax
     mov gs, ax
     mov ss, ax
-    ; restore cr3
-    mov cr3, ebx
-    ; restore esp
-    mov esp, edx
-    sti
+
+    ; retore esp
+    mov esp, [REBASE_ADDRESS(prot_esp)]
+
+    ; Reload the original IDTr and GDTr from the stack
+    lidt [esp]
+    lgdt [esp + 16]
+    add esp, 32
+
+    ; Restore all registers
     popa
+
+    ; Restore flags including IF state
+    popf
     ret
 
 
-__padding:
-    db 0x0
-    db 0x0
-    db 0x0
+align 4
+
 bios32_gdt_entries:
     ; 8 gdt entries
-    resb 64
+    TIMES 8 dq 0
 bios32_gdt_ptr:
     dd 0x00000000
     dd 0x00000000
@@ -170,6 +194,8 @@ bios32_out_reg16_ptr:
     dd 0xaaaaaaaa
     dd 0xaaaaaaaa
 current_esp:
-    dw 0x0000
+    dd 0x0000
+prot_esp:
+    dd 0x0000
 
 BIOS32_END:


### PR DESCRIPTION
Hi,

I've noticed a few bugs in your BIOS32 implementation that I myself had, and later fixed.

For instance - you called `sti` to enable interrupts, but that will also enable external interrupts which have not been mapped in the IDT/GDT (since they are real mode) and will crash the system if BIOS32 is used in a more high-level environment.

A few other fixes, such as not clobbering a few other registers and flushing the TLB after disabling paging, and here is my result.

Your previous code, while it works, will cause issues if used in a higher-level system, like my OS. I learned and solved these bugs the hard way. Specifically, BIOS32 causes serious issues when combined with virtual memory management.

I have tested the code changes and they pass the tests, and produce the same results as your old code but can be used in higher-level implementations.

I hope this helps! Please let me know if further changes are needed.